### PR TITLE
Handle empty repos which return capabilities

### DIFF
--- a/src/wire/parseRefsAdResponse.js
+++ b/src/wire/parseRefsAdResponse.js
@@ -42,6 +42,10 @@ export async function parseRefsAdResponse(stream, { service }) {
   const [firstRef, capabilitiesLine] = splitAndAssert(lineTwo, '\x00', '\\x00')
   capabilitiesLine.split(' ').map(x => capabilities.add(x))
   const [ref, name] = splitAndAssert(firstRef, ' ', ' ')
+  // Handle an empty repo where the server returns capabilities
+  if (name === "capabilities^{}" && ref === "0000000000000000000000000000000000000000") {
+    return { capabilities, refs, symrefs };
+  }
   refs.set(name, ref)
   while (true) {
     const line = await read()


### PR DESCRIPTION
The Git wire protocol has a special hack to support returning capabilities on empty repos. As of Git version 1.43 the git-http-backend is using this, which means we need to support it.